### PR TITLE
potential sizing assistance

### DIFF
--- a/configfiles-5.x/1116_preprocess_bro_ssl.conf
+++ b/configfiles-5.x/1116_preprocess_bro_ssl.conf
@@ -70,7 +70,7 @@ filter {
     }
     if [issuer_common_name] {
       ruby {
-        code => "event.set('issier_common_name_length', event.get('issuer_common_name').length)"
+        code => "event.set('issuer_common_name_length', event.get('issuer_common_name').length)"
       }
     }
     if [server_name] == "-" {

--- a/configfiles-5.x/8006_postprocess_dns.conf
+++ b/configfiles-5.x/8006_postprocess_dns.conf
@@ -1,15 +1,10 @@
 # Author: Justin Henderson
 #         SANS Instructor and author of SANS SEC555: SIEM and Tactical Analytics
 # Email: justin@hasecuritysolutions.com
-# Last Update: 01/02/2018 <tyler.bennett@como.gov>
+# Last Update: 01/10/2018 <tyler.bennett@como.gov>
 
 filter {
-  if [type] == "bro_dns" {
-    mutate {
-      replace => { "type" => "dns" }
-    }
-  }
-  if [type] == "dns" {
+  if [type] == "dns" or [type] == "bro_dns" {
     # Used for whois lookups - can create log loop
     if [query] =~ "^whois\." {
       drop { }

--- a/configfiles/6302_windows_translations.conf
+++ b/configfiles/6302_windows_translations.conf
@@ -1,0 +1,187 @@
+## Author: Tyler Bennett
+##
+## Email: tyler.bennett@como.gov
+## Last Update: 3/19/2018
+## Compatability: 6.2.1
+## 
+## @link https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
+## @link https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4624
+
+filter {
+	if [log_event_type] == "windows" {
+   
+        # If LogonType is a set field
+        if ("" in [LogonType]) {
+            mutate {
+                copy => { "LogonType" => "LogonTypeNumeric" }
+                convert => [ "LogonTypeNumeric", "integer" ]
+            } 
+
+            translate {
+              field => "LogonType"
+              
+              destination => "LogonType"
+              
+              dictionary => [
+                            "2", "Interactive (Console logon)",
+                            "3", "Network (Connection to shared folders)",
+                            "4", "Batch (Scheduled task)",
+                            "5", "Service (Service startup)",
+                            "7", "Unlock (Unnattended locked workstation)",
+                            "8", "NetworkCleartext (Logon with credentials sent in the clear text. Most often indicates a logon to IIS with 'basic authentication')",
+                            "9", "NewCredentials (Such as with RunAs or mapping a network drive with alternate credentials)",
+                            "10", "RemoteInteractive (Terminal Services, Remote Desktop or Remote Assistance)",
+                            "11", "CachedInteractive (logon with cached domain credentials)"
+                            ]
+              override => true
+            }
+        } ##END if-LogonType
+
+        
+        # If SubjectUserSid is a set field
+        if ("" in [SubjectUserSid]) {
+            mutate {
+                copy => { "SubjectUserSid" => "SubjectUserSidNumeric" }
+            } 
+
+            translate {
+              field => "SubjectUserSid"
+              
+              destination => "SubjectUserSid"
+              
+              dictionary => [
+                                "S-1-0", "Null Authority",
+                                "S-1-0-0", "Nobody",
+                                "S-1-1", "World Authority",
+                                "S-1-1-0", "Everyone",
+                                "S-1-2", "Local Authority",
+                                "S-1-2-0", "Local",
+                                "S-1-2-1", "Console Logon",
+                                "S-1-3", "Creator Authority",
+                                "S-1-3-0", "Creator Owner",
+                                "S-1-3-1", "Creator Group",
+                                "S-1-3-2", "Creator Owner Server",
+                                "S-1-3-3", "Creator Group Server",
+                                "S-1-3-4", "Owner Rights",
+                                "S-1-5-80-0", "All Services",
+                                "S-1-4", "Non-unique Authority",
+                                "S-1-5", "NT Authority",
+                                "S-1-5-1", "Dialup",
+                                "S-1-5-2", "Network",
+                                "S-1-5-3", "Batch",
+                                "S-1-5-4", "Interactive",
+                                "S-1-5-6", "Service",
+                                "S-1-5-7", "Anonymous",
+                                "S-1-5-8", "Proxy",
+                                "S-1-5-9", "Enterprise Domain Controllers",
+                                "S-1-5-10", "Principal Self",
+                                "S-1-5-11", "Authenticated Users",
+                                "S-1-5-12", "Restricted Code",
+                                "S-1-5-13", "Terminal Server Users",
+                                "S-1-5-14", "Remote Interactive Logon",
+                                "S-1-5-15", "This Organization",
+                                "S-1-5-17", "This Organization",
+                                "S-1-5-18", "Local System",
+                                "S-1-5-19", "NT Authority",
+                                "S-1-5-20", "NT Authority",
+                                "S-1-5-32-544", "Administrators",
+                                "S-1-5-32-545", "Users",
+                                "S-1-5-32-546", "Guests",
+                                "S-1-5-32-547", "Power Users",
+                                "S-1-5-32-548", "Account Operators",
+                                "S-1-5-32-549", "Server Operators",
+                                "S-1-5-32-550", "Print Operators",
+                                "S-1-5-32-551", "Backup Operators",
+                                "S-1-5-32-552", "Replicators",
+                                "S-1-5-64-10", "NTLM Authentication",
+                                "S-1-5-64-14", "SChannel Authentication",
+                                "S-1-5-64-21", "Digest Authentication",
+                                "S-1-5-80", "NT Service",
+                                "S-1-5-80-0", "NT SERVICES\ALL SERVICES",
+                                "S-1-5-83-0", "NT VIRTUAL MACHINE\Virtual Machines",
+                                "S-1-16-0", "Untrusted Mandatory Level",
+                                "S-1-16-4096", "Low Mandatory Level",
+                                "S-1-16-8192", "Medium Mandatory Level",
+                                "S-1-16-8448", "Medium Plus Mandatory Level",
+                                "S-1-16-12288", "High Mandatory Level",
+                                "S-1-16-16384", "System Mandatory Level",
+                                "S-1-16-20480", "Protected Process Mandatory Level",
+                                "S-1-16-28672", "Secure Process Mandatory Level"
+                            ]
+              override => true
+            }
+        } ##END if-SubjectUserSid
+        
+        if ("" in [TargetUserSid]) {
+            mutate {
+                copy => { "TargetUserSid" => "TargetUserSidNumeric" }
+            }
+            translate {
+              field => "TargetUserSid"
+              
+              destination => "TargetUserSid"
+              
+              dictionary => [
+                                "S-1-0", "Null Authority",
+                                "S-1-0-0", "Nobody",
+                                "S-1-1", "World Authority",
+                                "S-1-1-0", "Everyone",
+                                "S-1-2", "Local Authority",
+                                "S-1-2-0", "Local",
+                                "S-1-2-1", "Console Logon",
+                                "S-1-3", "Creator Authority",
+                                "S-1-3-0", "Creator Owner",
+                                "S-1-3-1", "Creator Group",
+                                "S-1-3-2", "Creator Owner Server",
+                                "S-1-3-3", "Creator Group Server",
+                                "S-1-3-4", "Owner Rights",
+                                "S-1-5-80-0", "All Services",
+                                "S-1-4", "Non-unique Authority",
+                                "S-1-5", "NT Authority",
+                                "S-1-5-1", "Dialup",
+                                "S-1-5-2", "Network",
+                                "S-1-5-3", "Batch",
+                                "S-1-5-4", "Interactive",
+                                "S-1-5-6", "Service",
+                                "S-1-5-7", "Anonymous",
+                                "S-1-5-8", "Proxy",
+                                "S-1-5-9", "Enterprise Domain Controllers",
+                                "S-1-5-10", "Principal Self",
+                                "S-1-5-11", "Authenticated Users",
+                                "S-1-5-12", "Restricted Code",
+                                "S-1-5-13", "Terminal Server Users",
+                                "S-1-5-14", "Remote Interactive Logon",
+                                "S-1-5-15", "This Organization",
+                                "S-1-5-17", "This Organization",
+                                "S-1-5-18", "Local System",
+                                "S-1-5-19", "NT Authority",
+                                "S-1-5-20", "NT Authority",
+                                "S-1-5-32-544", "Administrators",
+                                "S-1-5-32-545", "Users",
+                                "S-1-5-32-546", "Guests",
+                                "S-1-5-32-547", "Power Users",
+                                "S-1-5-32-548", "Account Operators",
+                                "S-1-5-32-549", "Server Operators",
+                                "S-1-5-32-550", "Print Operators",
+                                "S-1-5-32-551", "Backup Operators",
+                                "S-1-5-32-552", "Replicators",
+                                "S-1-5-64-10", "NTLM Authentication",
+                                "S-1-5-64-14", "SChannel Authentication",
+                                "S-1-5-64-21", "Digest Authentication",
+                                "S-1-5-80", "NT Service",
+                                "S-1-5-80-0", "NT SERVICES\ALL SERVICES",
+                                "S-1-5-83-0", "NT VIRTUAL MACHINE\Virtual Machines",
+                                "S-1-16-0", "Untrusted Mandatory Level",
+                                "S-1-16-4096", "Low Mandatory Level",
+                                "S-1-16-8192", "Medium Mandatory Level",
+                                "S-1-16-8448", "Medium Plus Mandatory Level",
+                                "S-1-16-12288", "High Mandatory Level",
+                                "S-1-16-16384", "System Mandatory Level",
+                                "S-1-16-20480", "Protected Process Mandatory Level",
+                                "S-1-16-28672", "Secure Process Mandatory Level"
+                            ]
+              override => true
+            }
+        } ##END if-TargetUserSid
+  } ##END if-windows
+} ##END filter

--- a/configfiles/8006_postprocess_dns.conf
+++ b/configfiles/8006_postprocess_dns.conf
@@ -1,15 +1,10 @@
 # Author: Justin Henderson
 #         SANS Instructor and author of SANS SEC555: SIEM and Tactical Analytics
 # Email: justin@hasecuritysolutions.com
-# Last Update: 12/9/2016
+# Last Update: 01/10/2018 <tyler.bennett@como.gov>
 
 filter {
-  if [type] == "bro_dns" {
-    mutate {
-      replace => { "type" => "dns" }
-    }
-  }
-  if [type] == "dns" {
+  if [type] == "dns" or [type] == "bro_dns" {
     # Used for whois lookups - can create log loop
     if [query] =~ "^whois\." {
       drop { }

--- a/configfiles/9000_output_bro.conf
+++ b/configfiles/9000_output_bro.conf
@@ -17,7 +17,7 @@ output {
       index => "logstash-bro-%{+YYYY.MM.dd}"
 	  
 	  # sizing and filtering assistance
-	  #index => "logstash-${type}-%{+YYYY.MM.dd}"
+	  #index => "logstash-%{type}-%{+YYYY.MM.dd}"
     }
   }
 }

--- a/configfiles/9000_output_bro.conf
+++ b/configfiles/9000_output_bro.conf
@@ -1,7 +1,7 @@
 # Author: Justin Henderson
 #         SANS Instructor and author of SANS SEC555: SIEM and Tactical Analytics
 # Email: justin@hasecuritysolutions.com
-# Last Update: 12/9/2016
+# Last Update: 01/10/2018 <tyler.bennett@como.gov>
 
 filter {
   if "bro" in [tags] and "test_data" not in [tags] {
@@ -15,6 +15,9 @@ output {
 #    stdout { codec => rubydebug }
     elasticsearch {
       index => "logstash-bro-%{+YYYY.MM.dd}"
+	  
+	  # sizing and filtering assistance
+	  #index => "logstash-${type}-%{+YYYY.MM.dd}"
     }
   }
 }


### PR DESCRIPTION
In the course of our POC we were indexing 70+ GB's in bro alone, and we used the following modifications to get a better sense of how this data was being partitioned. Splitting the index's up as allowed use to use different retention for the various bro types.

`index => "logstash-%{type}-%{+YYYY.MM.dd}"`

We were going to go with `logstash-bro-%{type}` but then we got `logstash-bro-bro` so we used the above setting. The only inconsistency we found was the bro_dns field as it was being replaced in 8006.

In our environment we have dns tagged already and I think the performance of a boolean check should be negligible compared to the now removed replace{} plugin.